### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/OTHERSUSAGE.md
+++ b/OTHERSUSAGE.md
@@ -1,6 +1,6 @@
-#Usage of Auxilary Viproy Modules
+# Usage of Auxilary Viproy Modules
 
-##CDP Tester
+## CDP Tester
 
 set INTERFACE en5<br>
 set ACTION Sniffer<br>
@@ -15,9 +15,9 @@ run<br>
 
 http://www.viproy.com/captures/viproy_cdp.pcapng<br>
 
-#Cisco CUCDM Testing Modules Usage
+# Cisco CUCDM Testing Modules Usage
 
-##Call Forwarding
+## Call Forwarding
 
 use auxiliary/voip/viproy_cucdm_callforward <br>
 set RHOST 192.168.1.151<br>
@@ -35,7 +35,7 @@ run<br>
 
 http://www.viproy.com/captures/viproy_cucdm_callforward.pcapng<br>
 
-##Speeddial Manipulation
+## Speeddial Manipulation
 
 use auxiliary/voip/viproy_cucdm_speeddials <br>
 set RHOST 192.168.1.151<br>
@@ -61,4 +61,4 @@ run<br><br>
 set ACTION INFO<br>
 run<br>
 
-http://www.viproy.com/captures/viproy_cucdm_speeddial.pcapng<br>
+http://www.viproy.com/captures/viproy_cucdm_speeddial.pcapng<br

--- a/SIPUSAGE.md
+++ b/SIPUSAGE.md
@@ -1,6 +1,6 @@
-#SIP Modules Usage
+# SIP Modules Usage
 
-##Register 
+## Register 
 
 use auxiliary/voip/viproy_sip_register <br>
 set RHOSTS 192.168.1.222 <br>
@@ -15,7 +15,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_register.pcapng<br>
 
-##Options 
+## Options 
 
 use auxiliary/voip/viproy_sip_options <br>
 set RHOSTS 192.168.1.221-222<br>
@@ -26,7 +26,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_options.pcapng<br>
 
-##Negotiate 
+## Negotiate 
 
 use auxiliary/voip/viproy_sip_negotiate <br>
 set RHOSTS 192.168.1.221-222<br>
@@ -37,7 +37,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_negotiate.pcapng<br>
 
-##Subscribe 
+## Subscribe 
 
 use auxiliary/voip/viproy_sip_subscribe<br>
 set RHOST 192.168.1.221<br>
@@ -48,7 +48,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_subscribe.pcapng<br>
 
-##Enumerate 
+## Enumerate 
 
 use auxiliary/voip/viproy_sip_enumerate <br>
 set RHOST 192.168.1.221<br>
@@ -61,7 +61,7 @@ run<br>
 http://www.viproy.com/captures/sip_enumerate.pcapng<br>
 
 
-##Brute Force 
+## Brute Force 
 
 use auxiliary/voip/viproy_sip_bruteforce <br>
 set RHOST 192.168.1.221<br>
@@ -75,7 +75,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_bruteforce.pcapng<br>
 
-##Invite
+## Invite
 
 use auxiliary/voip/viproy_sip_invite <br>
 show options <br>
@@ -92,7 +92,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_invite.pcapng<br>
 
-##Message
+## Message
 
 use auxiliary/voip/viproy_sip_message<br>
 show options <br>
@@ -107,7 +107,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_message.pcapng<br>
 
-##Proxy Bounce Scan
+## Proxy Bounce Scan
 
 use auxiliary/voip/viproy_sip_proxybouncescan <br>
 show options <br>
@@ -120,7 +120,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_proxybouncescan.pcapng<br>
 
-##UDP Amplification DOS
+## UDP Amplification DOS
 
 use auxiliary/voip/viproy_sip_udpampdos <br>
 set SIP_SERVERS 192.168.1.221<br>
@@ -132,7 +132,7 @@ run<br>
 
 http://www.viproy.com/captures/sip_udpampdos.pcapng<br>
 
-##UDP Trust Hacking
+## UDP Trust Hacking
 
 use auxiliary/voip/viproy_sip_trusthacking <br>
 set SRC_RHOSTS 192.168.1.220-225<br>

--- a/SKINNYUSAGE.md
+++ b/SKINNYUSAGE.md
@@ -1,6 +1,6 @@
-#Skinny Modules Usage
+# Skinny Modules Usage
 
-##Skinny Registration
+## Skinny Registration
 
 use auxiliary/voip/viproy_skinny_register <br>
 set RHOST 192.168.0.205<br>
@@ -13,7 +13,7 @@ run<br>
 
 http://www.viproy.com/captures/skinny_register.pcapng<br>
 
-##Skinny Call Forward
+## Skinny Call Forward
 
 use auxiliary/voip/viproy_skinny_callforward <br>
 set RHOST 192.168.0.205<br>
@@ -25,7 +25,7 @@ run<br>
 
 http://www.viproy.com/captures/skinny_callforward.pcapng<br>
 
-##Skinny Call
+## Skinny Call
 
 use auxiliary/voip/viproy_skinny_call<br>
 set MAC 000C29E58CA3<br>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
