### PR TITLE
Update files to make it work with latest Metasploit version

### DIFF
--- a/kaliinstall.sh
+++ b/kaliinstall.sh
@@ -1,6 +1,12 @@
 cp lib/msf/core/auxiliary/* /usr/share/metasploit-framework/lib/msf/core/auxiliary/
-echo "require 'msf/core/auxiliary/sip'" >> /usr/share/metasploit-framework/lib/msf/core/auxiliary/mixins.rb
-echo "require 'msf/core/auxiliary/skinny'" >> /usr/share/metasploit-framework/lib/msf/core/auxiliary/mixins.rb
+cat << EOF >> /usr/share/metasploit-framework/lib/msf/core/auxiliary/mixins.rb
+require 'msf/core/auxiliary/sip'
+require 'msf/core/auxiliary/skinny'
+require 'msf/core/auxiliary/msrp'
+
+Msf::Auxiliary::Mixins = ""
+EOF
+
 cp modules/auxiliary/voip/viproy* /usr/share/metasploit-framework/modules/auxiliary/voip/
 cp modules/auxiliary/spoof/cisco/viproy_cdp.rb /usr/share/metasploit-framework/modules/auxiliary/spoof/cisco/
 printf "You can execute msfconsole now.\nViproy modules placed under auxiliary/voip/viproy*\n"

--- a/lib/msf/core/auxiliary/msrp.rb
+++ b/lib/msf/core/auxiliary/msrp.rb
@@ -10,6 +10,8 @@
 require 'rex/socket'
 require 'timeout'
 
+Msf::Auxiliary::Msrp = ""
+
 module Msf
 
 module Auxiliary::MSRP


### PR DESCRIPTION
Update files to make it work with latest Metasploit version. Because the latest Metasploit version has a new code loader (called zeitwerk), which generates multiple errors when trying to install viproy modules in metasploit.